### PR TITLE
feat: Smart pointer for passing Connection around

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ Open issues and TODOs:
 - [ ] Provide examples
 - [ ] Documentation
 - [ ] Test suite
-- [ ] Investigate smart pointers instead of passing raw pointers around
+- [X] Investigate smart pointers instead of passing raw pointers around

--- a/src/include/qwsengine/authmiddleware.h
+++ b/src/include/qwsengine/authmiddleware.h
@@ -41,7 +41,7 @@ class QWSENGINE_EXPORT AuthMiddleware : public Middleware {
      * An error message with code 401 "Authentication required" is sent to the
      * client if the corresponding %Connection is not yet authenticated.
      */
-    bool process(Connection *connection, const QString &msgName, const QVariant &message) override;
+    bool process(QSharedPointer<Connection> connection, const QString &msgName, const QVariant &message) override;
 
  private:
     AuthMiddlewarePrivate *const d;

--- a/src/include/qwsengine/connection.h
+++ b/src/include/qwsengine/connection.h
@@ -4,9 +4,11 @@
 #pragma once
 
 #include <QByteArray>
+#include <QEnableSharedFromThis>
 #include <QJsonObject>
 #include <QList>
 #include <QObject>
+#include <QScopedPointer>
 #include <QString>
 #include <QtWebSockets/QWebSocket>
 
@@ -20,8 +22,10 @@ class ConnectionPrivate;
 
 /**
  * @brief Each client connection is represented in a Connection instance, managed by ConnectionHandler.
+ *
+ * The Connection takes ownership of the provided QWebSocket object.
  */
-class QWSENGINE_EXPORT Connection : public QObject {
+class QWSENGINE_EXPORT Connection : public QObject, public QEnableSharedFromThis<QWsEngine::Connection> {
     Q_OBJECT
 
  public:
@@ -46,7 +50,7 @@ class QWSENGINE_EXPORT Connection : public QObject {
     qint64 sendTextMessage(const QString &message);
     qint64 sendBinaryMessage(const QByteArray &data);
 
- public Q_SLOTS: // NOLINT
+ public Q_SLOTS:  // NOLINT
     void processTextMessage(const QString &message);
     void processBinaryMessage(const QByteArray &message);
 
@@ -54,7 +58,7 @@ class QWSENGINE_EXPORT Connection : public QObject {
                const QString &               reason = QString());
 
  private:
-    ConnectionPrivate *const d;
+    QScopedPointer<ConnectionPrivate> const d;
     friend class ConnectionPrivate;
 };
 

--- a/src/include/qwsengine/connectionhandler.h
+++ b/src/include/qwsengine/connectionhandler.h
@@ -5,6 +5,7 @@
 
 #include <QObject>
 #include <QRegExp>
+#include <QSharedPointer>
 #include <QtWebSockets/QWebSocket>
 
 #include "qwsengine_export.h"
@@ -58,7 +59,7 @@ class QWSENGINE_EXPORT ConnectionHandler : public QObject {
     /**
      * @brief Route an incoming connection
      */
-    Connection *route(QWebSocket *socket, const QString &path);
+    QSharedPointer<QWsEngine::Connection> route(QWebSocket *socket, const QString &path);
 
     /**
      * @brief Set the root message handler for the created connections
@@ -74,14 +75,14 @@ class QWSENGINE_EXPORT ConnectionHandler : public QObject {
      * QWsEngine::Connection), or if the connection is rejected returning nullptr and deleting the socket after writing
      * an error to the socket and closing it.
      */
-    virtual Connection *process(QWebSocket *socket, const QString &path);
+    virtual QSharedPointer<QWsEngine::Connection> process(QWebSocket *socket, const QString &path);
 
     /**
      * @brief Connection creation hook.
      *
      * Override to create custom connections.
      */
-    virtual Connection *createConnection(QWebSocket *socket, bool authenticated = false);
+    virtual QSharedPointer<QWsEngine::Connection> createConnection(QWebSocket *socket, bool authenticated = false);
 
  private:
     ConnectionHandlerPrivate *const d;

--- a/src/include/qwsengine/handler.h
+++ b/src/include/qwsengine/handler.h
@@ -5,6 +5,7 @@
 
 #include <QByteArray>
 #include <QObject>
+#include <QSharedPointer>
 #include <QString>
 #include <QVariant>
 #include <QtWebSockets/QWebSocket>
@@ -58,14 +59,14 @@ class QWSENGINE_EXPORT Handler : public QObject {
     void    setAuthRequiredMsgTemplate(const QString &messageTemplate);
     QString authRequiredMsgTemplate() const;
 
-    virtual void routeTextMessage(Connection *connection, const QString &message);
-    virtual void routeBinaryMessage(Connection *connection, const QByteArray &message);
+    virtual void routeTextMessage(QSharedPointer<Connection> connection, const QString &message);
+    virtual void routeBinaryMessage(QSharedPointer<Connection> connection, const QByteArray &message);
 
  protected:
     /**
      * @brief Route an incoming message
      */
-    void route(Connection *connection, const QString &msgName, const QVariant &message);
+    void route(QSharedPointer<Connection> connection, const QString &msgName, const QVariant &message);
 
     /**
      * @brief Process a message
@@ -73,7 +74,7 @@ class QWSENGINE_EXPORT Handler : public QObject {
      * This method should process the message either by fulfilling it, or
      * writing an error to the socket.
      */
-    virtual void process(Connection *connection, const QString &msgName, const QVariant &message);
+    virtual void process(QSharedPointer<Connection> connection, const QString &msgName, const QVariant &message);
 
  private:
     HandlerPrivate *const d;

--- a/src/include/qwsengine/headerauthconnectionhandler.h
+++ b/src/include/qwsengine/headerauthconnectionhandler.h
@@ -61,7 +61,7 @@ class HeaderAuthConnectionHandler : public ConnectionHandler {
     /**
      * @brief Reimplementation of [ConnectionHandler::process()](QWsEngine::ConnectionHandler::process)
      */
-    Connection *process(QWebSocket *socket, const QString &path) override;
+    QSharedPointer<Connection> process(QWebSocket *socket, const QString &path) override;
 
  private:
     HeaderAuthConnectionHandlerPrivate *const d;

--- a/src/include/qwsengine/middleware.h
+++ b/src/include/qwsengine/middleware.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <QObject>
+#include <QSharedPointer>
 #include <QVariant>
 #include <QtWebSockets/QWebSocket>
 
@@ -42,7 +43,7 @@ class QWSENGINE_EXPORT Middleware : public QObject {
      * returned, processing continues. Otherwise, it is assumed that an
      * appropriate error was written to the socket.
      */
-    virtual bool process(Connection *connection, const QString &msgName, const QVariant &message) = 0;
+    virtual bool process(QSharedPointer<Connection> connection, const QString &msgName, const QVariant &message) = 0;
 };
 
 }  // namespace QWsEngine

--- a/src/include/qwsengine/msgauthconnectionhandler.h
+++ b/src/include/qwsengine/msgauthconnectionhandler.h
@@ -36,7 +36,7 @@ class QWSENGINE_EXPORT MsgAuthConnectionHandler : public ConnectionHandler {
     virtual bool isFailedAuthClosesConnection() const;
 
  protected:
-    Connection *createConnection(QWebSocket *socket, bool authenticated = false) override;
+    QSharedPointer<Connection> createConnection(QWebSocket *socket, bool authenticated = false) override;
 
  private:
     MsgAuthConnectionHandlerPrivate *const d;

--- a/src/include/qwsengine/msgauthmiddleware.h
+++ b/src/include/qwsengine/msgauthmiddleware.h
@@ -6,6 +6,8 @@
 #include <qwsengine/middleware.h>
 #include <qwsengine/tokenauthenticator.h>
 
+#include <QSharedPointer>
+
 #include "qwsengine_export.h"
 
 namespace QWsEngine {
@@ -50,7 +52,7 @@ class QWSENGINE_EXPORT MsgAuthMiddleware : public Middleware {
     void setFailedAuthClosesSocket(bool close);
     bool isFailedAuthClosesSocket() const;
 
-    bool process(Connection *connection, const QString &msgName, const QVariant &message) override;
+    bool process(QSharedPointer<Connection> connection, const QString &msgName, const QVariant &message) override;
 
  private:
     MsgAuthMiddlewarePrivate *const d;

--- a/src/include/qwsengine/qobjecthandler.h
+++ b/src/include/qwsengine/qobjecthandler.h
@@ -55,7 +55,7 @@ class QObjectHandlerPrivate;
  * QWsEngine::QObjectHandler handler;
  * Object object;
  * // Old connection syntax
- * handler.registerMessage("something", &object, SLOT(something(QWsEngine::Connection*)));
+ * handler.registerMessage("something", &object, SLOT(something(QSharedPointer<QWsEngine::Connection>)));
  * // New connection syntax
  * handler.registerMessage("something", &object, &Object::something);
  * @endcode
@@ -65,7 +65,7 @@ class QObjectHandlerPrivate;
  *
  * @code
  * QWsEngine::QObjectHandler handler;
- * handler.registerMessage("something", [](QWsEngine::Connection *connection) {
+ * handler.registerMessage("something", [](QSharedPointer<QWsEngine::Connection> connection) {
  *     // do something
  *     connection->close();
  * });
@@ -153,7 +153,7 @@ class QWSENGINE_EXPORT QObjectHandler : public Handler {
     /**
      * @brief Reimplementation of [Handler::process()](QWsEngine::Handler::process)
      */
-    void process(Connection *connection, const QString &msgName, const QVariant &message) override;
+    void process(QSharedPointer<Connection> connection, const QString &msgName, const QVariant &message) override;
 
  private:
     template <typename Func1, typename Func1Operator>

--- a/src/include/qwsengine/server.h
+++ b/src/include/qwsengine/server.h
@@ -12,18 +12,28 @@ namespace QWsEngine {
 class ConnectionHandler;
 class ServerPrivate;
 
+/**
+ * @brief WebSocket server extending Qt's QWebSocketServer for convenient JSON payload handling in text messages.
+ *
+ * The QWebSocket instance retrieved for new client connections is managed by QWsEngine::Connection, which in turn is
+ * passed around with a QSharedPointer. The server keeps track of all open QWebSocket instances. The QWebSocket's
+ * disconnect() signal is used to ensure that the connection and socket objects are deleted when the client disconnects.
+ */
 class QWSENGINE_EXPORT Server : public QWebSocketServer {
     Q_OBJECT
 
  public:
     /**
-     * @brief Create a WebSocket server
+     * @brief Constructs a new WebSocket server.
+     *
+     * Simply calls the corresponding QWebSocketServer constructor.
+     * The method setHandler must be called separately to initialize and use the server.
      */
     explicit Server(const QString &serverName = QString(), SslMode secureMode = QWebSocketServer::NonSecureMode,
                     QObject *parent = nullptr);
 
     /**
-     * @brief Create a WebSocket server with the specified connection handler
+     * @brief Constructs a new WebSocket server with the specified connection handler.
      */
     Server(ConnectionHandler *handler, const QString &serverName = QString(),
            SslMode secureMode = QWebSocketServer::NonSecureMode, QObject *parent = nullptr);
@@ -31,7 +41,7 @@ class QWSENGINE_EXPORT Server : public QWebSocketServer {
     virtual ~Server();
 
     /**
-     * @brief Set the root connection handler for all new requests
+     * @brief Set the root connection handler for all new requests.
      */
     void setHandler(ConnectionHandler *handler);
 

--- a/src/src/authmiddleware.cpp
+++ b/src/src/authmiddleware.cpp
@@ -8,8 +8,7 @@
 
 namespace QWsEngine {
 
-AuthMiddlewarePrivate::AuthMiddlewarePrivate(AuthMiddleware *middleware)
-    : QObject(middleware), q(middleware) {}
+AuthMiddlewarePrivate::AuthMiddlewarePrivate(AuthMiddleware *middleware) : QObject(middleware), q(middleware) {}
 
 AuthMiddleware::AuthMiddleware(QObject *parent) : Middleware(parent), d(new AuthMiddlewarePrivate(this)) {}
 
@@ -19,8 +18,7 @@ QString AuthMiddleware::name() const {
     return "AuthCheck";
 }
 
-bool AuthMiddleware::process(Connection *connection, const QString &msgName,
-                                       const QVariant &message) {
+bool AuthMiddleware::process(QSharedPointer<Connection> connection, const QString &msgName, const QVariant &message) {
     Q_UNUSED(message)
 
     if (!connection->isAuthenticated()) {

--- a/src/src/connection.cpp
+++ b/src/src/connection.cpp
@@ -19,6 +19,7 @@ ConnectionPrivate::ConnectionPrivate(Connection *connection, QWebSocket *webSock
 
 ConnectionPrivate::~ConnectionPrivate() {
     qCDebug(wsEngine) << "ConnectionPrivate destructor";
+    socket->close();
     // socket may not be deleted immediately if triggered from QWebSocketServer::socketDisconnected
     socket->deleteLater();
 }

--- a/src/src/connection_p.h
+++ b/src/src/connection_p.h
@@ -16,6 +16,7 @@ class ConnectionPrivate : public QObject {
 
  public:
     explicit ConnectionPrivate(Connection *connection, QWebSocket *socket);
+    virtual ~ConnectionPrivate();
 
     QList<Middleware *> middleware;
 

--- a/src/src/connectionhandler.cpp
+++ b/src/src/connectionhandler.cpp
@@ -36,7 +36,7 @@ void ConnectionHandler::addSubHandler(const QRegExp &pattern, ConnectionHandler 
     d->subHandlers.append(ConnSubHandler(pattern, handler));
 }
 
-Connection *ConnectionHandler::route(QWebSocket *socket, const QString &path) {
+QSharedPointer<Connection> ConnectionHandler::route(QWebSocket *socket, const QString &path) {
     qCDebug(wsEngine) << name() << ": Routing new" << path
                       << "connection through the middleware from:" << socket->peerAddress().toString()
                       << socket->peerPort();
@@ -75,7 +75,7 @@ Handler *ConnectionHandler::messageHandler() {
     return d->handler;
 }
 
-Connection *ConnectionHandler::process(QWebSocket *socket, const QString &path) {
+QSharedPointer<Connection> ConnectionHandler::process(QWebSocket *socket, const QString &path) {
     if (d->handler) {
         // simple connection without authentication: therefore set connection as authenticated to allow message
         // processing
@@ -92,8 +92,8 @@ Connection *ConnectionHandler::process(QWebSocket *socket, const QString &path) 
     return nullptr;
 }
 
-Connection *ConnectionHandler::createConnection(QWebSocket *socket, bool authenticated) {
-    return new Connection(socket, d->handler, authenticated);
+QSharedPointer<Connection> ConnectionHandler::createConnection(QWebSocket *socket, bool authenticated) {
+    return QSharedPointer<Connection>::create(socket, d->handler, authenticated);
 }
 
 }  // namespace QWsEngine

--- a/src/src/handler.cpp
+++ b/src/src/handler.cpp
@@ -43,7 +43,7 @@ QString Handler::authRequiredMsgTemplate() const {
     return d->authTemplate;
 }
 
-void Handler::routeTextMessage(Connection *connection, const QString &message) {
+void Handler::routeTextMessage(QSharedPointer<Connection> connection, const QString &message) {
     qCDebug(wsEngine()) << "Converting WebSocket text message to JSON object";
 
     // TODO(zehnm) replace with MessageConverter
@@ -61,17 +61,17 @@ void Handler::routeTextMessage(Connection *connection, const QString &message) {
         return;
     }
     QJsonObject jsonObject = doc.object();
-    // TODO(zehnm) refactor to user settable MessageNameExctractor class
+    // TODO(zehnm) refactor to user settable MessageNameExtractor class
     QVariant test = QVariant(jsonObject);
     route(connection, jsonObject.value("type").toString(), test);
 }
 
-void Handler::routeBinaryMessage(Connection *connection, const QByteArray &message) {
+void Handler::routeBinaryMessage(QSharedPointer<Connection> connection, const QByteArray &message) {
     // TODO(zehnm) add MessageConverter
     route(connection, "binary", message);
 }
 
-void Handler::route(Connection *connection, const QString &msgName, const QVariant &message) {
+void Handler::route(QSharedPointer<Connection> connection, const QString &msgName, const QVariant &message) {
     // Run through each of the middleware
     foreach(Middleware *middleware, d->middleware) {
         if (!middleware->process(connection, msgName, message)) {
@@ -91,7 +91,7 @@ void Handler::route(Connection *connection, const QString &msgName, const QVaria
     process(connection, msgName, message);
 }
 
-void Handler::process(Connection *connection, const QString &msgName, const QVariant &message) {
+void Handler::process(QSharedPointer<Connection> connection, const QString &msgName, const QVariant &message) {
     Q_UNUSED(msgName)
     Q_UNUSED(message)
     if (connection->isAuthenticated()) {

--- a/src/src/headerauthconnectionhandler.cpp
+++ b/src/src/headerauthconnectionhandler.cpp
@@ -68,7 +68,7 @@ bool HeaderAuthConnectionHandler::isFailedAuthCreatesConnection() const {
     return d->failedAuthCreatesConnection;
 }
 
-Connection *HeaderAuthConnectionHandler::process(QWebSocket *socket, const QString &path) {
+QSharedPointer<Connection> HeaderAuthConnectionHandler::process(QWebSocket *socket, const QString &path) {
     auto networkRequest = socket->request();
     auto headerName = d->tokenHeaderName.toUtf8();
     bool authenticated = false;

--- a/src/src/msgauthmiddleware.cpp
+++ b/src/src/msgauthmiddleware.cpp
@@ -59,7 +59,8 @@ bool MsgAuthMiddleware::isFailedAuthClosesSocket() const {
     return d->failedAuthClosesSocket;
 }
 
-bool MsgAuthMiddleware::process(Connection *connection, const QString &msgName, const QVariant &message) {
+bool MsgAuthMiddleware::process(QSharedPointer<Connection> connection, const QString &msgName,
+                                const QVariant &message) {
     if (message.type() != QMetaType::QJsonObject) {
         // not a json object message, continue.
         qCWarning(wsEngine()) << "Expected QJsonObject message but got:" << message.typeName();

--- a/src/src/qobjecthandler.cpp
+++ b/src/src/qobjecthandler.cpp
@@ -20,25 +20,21 @@
  * IN THE SOFTWARE.
  */
 
+#include <qwsengine/connection.h>
+#include <qwsengine/qobjecthandler.h>
+
 #include <QGenericArgument>
 #include <QMetaMethod>
-
-#include <qwsengine/qobjecthandler.h>
-#include <qwsengine/connection.h>
 
 #include "qobjecthandler_p.h"
 
 namespace QWsEngine {
 
-QObjectHandlerPrivate::QObjectHandlerPrivate(QObjectHandler *handler)
-    : QObject(handler),
-      q(handler) {}
+QObjectHandlerPrivate::QObjectHandlerPrivate(QObjectHandler *handler) : QObject(handler), q(handler) {}
 
-QObjectHandler::QObjectHandler(QObject *parent)
-    : Handler(parent),
-      d(new QObjectHandlerPrivate(this)) {}
+QObjectHandler::QObjectHandler(QObject *parent) : Handler(parent), d(new QObjectHandlerPrivate(this)) {}
 
-void QObjectHandlerPrivate::invokeSlot(Connection *connection, const QVariant &message, Method m) {
+void QObjectHandlerPrivate::invokeSlot(QSharedPointer<Connection> connection, const QVariant &message, Method m) {
     // Invoke the slot
     if (m.oldSlot) {
         // Obtain the slot index
@@ -59,22 +55,21 @@ void QObjectHandlerPrivate::invokeSlot(Connection *connection, const QVariant &m
 
         // Invoke the method
         // TODO(zehnm) old slot code not yet tested !!!
-        if (!m.receiver->metaObject()->method(index).invoke(
-                    m.receiver, Q_ARG(Connection*, connection), Q_ARG(QVariant, message))) {
+        if (!m.receiver->metaObject()->method(index).invoke(m.receiver, Q_ARG(QSharedPointer<Connection>, connection),
+                                                            Q_ARG(QVariant, message))) {
             connection->sendErrorResponse(500);
             return;
         }
     } else {
         void *args[] = {
-            Q_NULLPTR,
-            &connection,
-            (void *)&message // NOLINT
+            Q_NULLPTR, &connection,
+            (void *)&message  // NOLINT
         };
         m.slot.slotObj->call(m.receiver, args);
     }
 }
 
-void QObjectHandler::process(Connection *connection, const QString &msgName, const QVariant &message) {
+void QObjectHandler::process(QSharedPointer<Connection> connection, const QString &msgName, const QVariant &message) {
     // Ensure the method has been registered
     if (!d->map.contains(msgName)) {
         connection->sendErrorResponse(404);

--- a/src/src/qobjecthandler_p.h
+++ b/src/src/qobjecthandler_p.h
@@ -25,6 +25,7 @@
 #include <QMap>
 #include <QObject>
 #include <QRegExp>
+#include <QSharedPointer>
 
 namespace QWsEngine {
 
@@ -58,7 +59,7 @@ class QObjectHandlerPrivate : public QObject {
         } slot;
     };
 
-    void invokeSlot(Connection *socket, const QVariant &message, Method m);
+    void invokeSlot(QSharedPointer<QWsEngine::Connection> connection, const QVariant &message, Method m);
 
     QMap<QString, Method> map;
 

--- a/src/src/server.cpp
+++ b/src/src/server.cpp
@@ -31,6 +31,8 @@ void ServerPrivate::onNewConnection() {
     QString path = socket->requestUrl().path();
 
     if (handler) {
+        // The QWebSocket is now managed by the Connection.
+        // If the connection routing fails, it will be closed and disposed with deleteLater().
         auto conn = handler->route(socket, path);
         if (conn) {
             qCDebug(wsEngine) << "Created new" << path << "client connection from:" << socket->peerAddress().toString()

--- a/src/src/server.cpp
+++ b/src/src/server.cpp
@@ -35,7 +35,7 @@ void ServerPrivate::onNewConnection() {
         if (conn) {
             qCDebug(wsEngine) << "Created new" << path << "client connection from:" << socket->peerAddress().toString()
                               << socket->peerPort();
-            connect(this, &ServerPrivate::disconnectAllClients, conn, &Connection::close);
+            connect(this, &ServerPrivate::disconnectAllClients, conn.data(), &Connection::close);
 
             connect(socket, &QWebSocket::disconnected, this, &ServerPrivate::socketDisconnected);
             connections.insert(socket, conn);
@@ -50,17 +50,14 @@ void ServerPrivate::onNewConnection() {
 
 void ServerPrivate::socketDisconnected() {
     QWebSocket *socket = qobject_cast<QWebSocket *>(sender());
-    if (socket) {
-        qCDebug(wsEngine) << "Client disconnected:" << socket->peerAddress().toString() << socket->peerPort();
-        if (connections.contains(socket)) {
-            qCDebug(wsEngine) << "Deleting connection";
-            auto *conn = connections.take(socket);
-            //            emit clientDisconnected(conn->clientInfo());
-            conn->deleteLater();
-        }
-        socket->close();  // TODO(zehnm) really required?
-        socket->deleteLater();
+    if (!(socket && connections.contains(socket))) {
+        return;
     }
+    qCDebug(wsEngine) << "Client disconnected, releasing connection:" << socket->peerAddress().toString()
+                      << socket->peerPort();
+    auto conn = connections.take(socket);
+    // as soon as the last reference is released, the Connection object will be deleted including QWebSocket!
+    conn.clear();
 }
 
 void ServerPrivate::onServerClosed() {

--- a/src/src/server_p.h
+++ b/src/src/server_p.h
@@ -7,6 +7,7 @@
 
 #include <QMap>
 #include <QObject>
+#include <QSharedPointer>
 #include <QtWebSockets/QWebSocket>
 
 namespace QWsEngine {
@@ -23,14 +24,14 @@ class ServerPrivate : public QObject {
     ConnectionHandler *handler;
     quint64            maxAllowedIncomingMessageSize;
 
-    QMap<QWebSocket *, Connection *> connections;
+    QMap<QWebSocket *, QSharedPointer<Connection>> connections;
 
- public Q_SLOTS: // NOLINT
+ public Q_SLOTS:  // NOLINT
     void onNewConnection();
     void onServerClosed();
     void socketDisconnected();
 
- Q_SIGNALS: // NOLINT
+ Q_SIGNALS:  // NOLINT
     void disconnectAllClients(QWebSocketProtocol::CloseCode closeCode = QWebSocketProtocol::CloseCodeNormal,
                               const QString &               reason = QString());
 


### PR DESCRIPTION
Use [QSharedPointer](https://doc.qt.io/qt-5/qsharedpointer.html) to safely access and release the `Connection` object